### PR TITLE
FIX: replace mock.call_count = 0 with mock.reset_mock()

### DIFF
--- a/tests/unit/islice_extended_test.py
+++ b/tests/unit/islice_extended_test.py
@@ -177,7 +177,7 @@ class Islice_extended_Test(unittest.TestCase):
         iteratorMock = build_IteratorMock(range(10))
         slicedIterator = islice_extended(iteratorMock, None)
         list(slicedIterator)    # consume the whole iterator
-        iteratorMock.__next__.call_count = 0
+        iteratorMock.__next__.reset_mock()
 
         # assert
         with self.assertRaises(StopIteration):

--- a/tests/unit/iteratorcounter_test.py
+++ b/tests/unit/iteratorcounter_test.py
@@ -50,7 +50,7 @@ class TestIteratorCounter(unittest.TestCase):
         # arrange
         iteratorMock = build_IteratorMock([1, 2, 3])
         counterIterator = IteratorCounter(iteratorMock)
-        iteratorMock.__iter__.call_count = 0
+        iteratorMock.__iter__.reset_mock()
 
         # act
         result = iter(counterIterator)
@@ -65,7 +65,7 @@ class TestIteratorCounter(unittest.TestCase):
         iteratorMock = build_IteratorMock([1, 2, 3])
         iterableMock = build_IterableMock(iteratorMock)
         counterIterator = IteratorCounter(iterableMock)
-        iterableMock.__iter__.call_count = 0
+        iterableMock.__iter__.reset_mock()
 
         # act
         result = iter(counterIterator)
@@ -116,7 +116,7 @@ class TestIteratorCounter(unittest.TestCase):
                 # arrange
                 iteratorMock = build_IteratorMock(input_data)
                 counterIterator = IteratorCounter(iteratorMock)
-                iteratorMock.__iter__.call_count = 0
+                iteratorMock.__iter__.reset_mock()
 
                 # act
                 list(counterIterator)
@@ -127,7 +127,7 @@ class TestIteratorCounter(unittest.TestCase):
                 self.assertEqual(iteratorMock.__next__.call_count, len(input_data) + 1)
 
                 # arrange
-                iteratorMock.__next__.call_count = 0
+                iteratorMock.__next__.reset_mock()
 
                 # act & assert
                 with self.assertRaises(StopIteration):


### PR DESCRIPTION
Python 3.14 changed _increment_mock_call to derive call_count from len(call_args_list) instead of incrementing it. This means manually setting call_count = 0 no longer works as the next call overwrites it with the cumulative total.

Use reset_mock() which properly clears both call_count and call_args_list, and has been the supported API since Python 3.3.