### PR TITLE
drop Python 3.9 support, require >= 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 description = "Providing some additional capabilities on top of itertools."
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 keywords = ["itertools", "python", "utilities", "iterators","islice"]
 dependencies = []
 classifiers = [


### PR DESCRIPTION
The codebase uses the X | Y type union syntax (PEP 604) in iteratorcounter.py which requires Python 3.10+ at runtime. Python 3.9 reached end-of-life in October 2025.