### PR TITLE
CI: run tests on all supported Python versions (3.10-3.14,3.x)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,6 +3,25 @@ on: [push, pull_request]
 jobs:
   unittests-job:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14', '3.x']
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Tests
+      run: |
+        python -m unittest discover -v -s "tests" -p "*_test.py" -t "."
+
+  coverage-job:
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python
@@ -13,9 +32,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-    - name: Tests
-      run: |
-        python -m unittest discover -v -s "tests" -p "*_test.py" -t "."
     - name: Coverage
       run: |
         coverage run -m unittest discover -s "tests" -p "*_test.py" -t "."


### PR DESCRIPTION
Split the tests workflow into two jobs:
- unittests-job: runs tests across Python 3.10, 3.11, 3.12, 3.13, 3.14 and the latest version 3.x
- coverage-job: runs coverage on latest Python only