### PR TITLE
Add PyPI/TestPyPI release workflow with version tooling

### DIFF
--- a/.github/scripts/version_tool.py
+++ b/.github/scripts/version_tool.py
@@ -1,0 +1,97 @@
+"""Read or bump the ``[project].version`` field in pyproject.toml.
+
+Provides a single source of truth for the project version so the release
+workflow does not re-implement parsing. Uses tomlkit to parse and write, which
+validates the TOML and preserves the rest of the file's formatting.
+
+Package indexes reject re-uploading an existing version, so builds get a unique
+per-run PEP 440 suffix: ``.devN`` (``set-dev``, TestPyPI sandbox builds) or
+``rcN`` (``set-rc``, GitHub pre-releases published to PyPI as release
+candidates). ``N`` is the GitHub run number.
+
+Usage:
+    python .github/scripts/version_tool.py get <pyproject_path>
+    python .github/scripts/version_tool.py set-dev <run_number> <pyproject_path>
+    python .github/scripts/version_tool.py set-rc <run_number> <pyproject_path>
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+import tomlkit
+from tomlkit.exceptions import TOMLKitError
+
+_USAGE = (
+    "usage:\n"
+    "  version_tool.py get <pyproject_path>\n"
+    "  version_tool.py set-dev <run_number> <pyproject_path>\n"
+    "  version_tool.py set-rc <run_number> <pyproject_path>"
+)
+
+
+def _load(pyproject_path: pathlib.Path) -> tomlkit.TOMLDocument:
+    try:
+        return tomlkit.parse(pyproject_path.read_text())
+    except TOMLKitError as error:
+        raise SystemExit(f"Invalid TOML in {pyproject_path}: {error}")
+
+
+def _read_version(pyproject_path: pathlib.Path) -> str:
+    document = _load(pyproject_path)
+    try:
+        return str(document["project"]["version"])
+    except (KeyError, TypeError):
+        raise SystemExit(f"No [project].version found in {pyproject_path}")
+
+
+def get_version(pyproject_path: pathlib.Path) -> str:
+    return _read_version(pyproject_path)
+
+
+def _write_version(pyproject_path: pathlib.Path, version: str) -> None:
+    document = _load(pyproject_path)
+    document["project"]["version"] = version
+    pyproject_path.write_text(tomlkit.dumps(document))
+
+
+def _set_version(pyproject_path: pathlib.Path, suffix: str) -> str:
+    new_version = f"{_read_version(pyproject_path)}{suffix}"
+    _write_version(pyproject_path, new_version)
+    return new_version
+
+
+def set_dev_version(pyproject_path: pathlib.Path, run_number: str) -> str:
+    return _set_version(pyproject_path, f".dev{run_number}")
+
+
+def set_rc_version(pyproject_path: pathlib.Path, run_number: str) -> str:
+    return _set_version(pyproject_path, f"rc{run_number}")
+
+
+def main(argv: list[str]) -> None:
+    if len(argv) < 2:
+        raise SystemExit(_USAGE)
+
+    command = argv[1]
+    if command == "get":
+        if len(argv) != 3:
+            raise SystemExit(_USAGE)
+        print(get_version(pathlib.Path(argv[2])))
+    elif command == "set-dev":
+        if len(argv) != 4:
+            raise SystemExit(_USAGE)
+        dev_version = set_dev_version(pathlib.Path(argv[3]), argv[2])
+        print(f"::notice::Building dev version {dev_version}")
+    elif command == "set-rc":
+        if len(argv) != 4:
+            raise SystemExit(_USAGE)
+        rc_version = set_rc_version(pathlib.Path(argv[3]), argv[2])
+        print(f"::notice::Building release candidate {rc_version}")
+    else:
+        raise SystemExit(_USAGE)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main(sys.argv)

--- a/.github/scripts/version_tool.py
+++ b/.github/scripts/version_tool.py
@@ -4,15 +4,20 @@ Provides a single source of truth for the project version so the release
 workflow does not re-implement parsing. Uses tomlkit to parse and write, which
 validates the TOML and preserves the rest of the file's formatting.
 
-Package indexes reject re-uploading an existing version, so builds get a unique
-per-run PEP 440 suffix: ``.devN`` (``set-dev``, TestPyPI sandbox builds) or
-``rcN`` (``set-rc``, GitHub pre-releases published to PyPI as release
-candidates). ``N`` is the GitHub run number.
+Two versioning modes:
+
+* ``set-dev`` / ``set-rc`` append a unique per-run PEP 440 suffix (``.devN`` for
+  TestPyPI sandbox builds, ``rcN`` for manual rc dispatches). ``N`` is the GitHub
+  run number, needed because package indexes reject re-uploading a version.
+* ``set-release`` publishes the tag-derived version of a GitHub Release. The tag
+  is validated (canonical PEP 440, base matching pyproject, rc-only
+  pre-releases) and any mismatch fails fast before anything is built.
 
 Usage:
     python .github/scripts/version_tool.py get <pyproject_path>
     python .github/scripts/version_tool.py set-dev <run_number> <pyproject_path>
     python .github/scripts/version_tool.py set-rc <run_number> <pyproject_path>
+    python .github/scripts/version_tool.py set-release <tag> <pyproject_path> [--prerelease]
 """
 
 from __future__ import annotations
@@ -21,13 +26,15 @@ import pathlib
 import sys
 
 import tomlkit
+from packaging.version import InvalidVersion, Version
 from tomlkit.exceptions import TOMLKitError
 
 _USAGE = (
     "usage:\n"
     "  version_tool.py get <pyproject_path>\n"
     "  version_tool.py set-dev <run_number> <pyproject_path>\n"
-    "  version_tool.py set-rc <run_number> <pyproject_path>"
+    "  version_tool.py set-rc <run_number> <pyproject_path>\n"
+    "  version_tool.py set-release <tag> <pyproject_path> [--prerelease]"
 )
 
 
@@ -70,6 +77,54 @@ def set_rc_version(pyproject_path: pathlib.Path, run_number: str) -> str:
     return _set_version(pyproject_path, f"rc{run_number}")
 
 
+def set_release_version(
+    pyproject_path: pathlib.Path, tag: str, prerelease: bool
+) -> str:
+    """Set the version from a GitHub Release tag, validating it first.
+
+    The tag must be ``v`` + a canonical PEP 440 version whose base matches the
+    pinned pyproject version. Full releases must equal the base exactly;
+    pre-releases must be a release candidate (``vX.Y.ZrcN``) with no other
+    segments. Any mismatch raises SystemExit so the release fails fast.
+    """
+    if not tag.startswith("v"):
+        raise SystemExit(f"Release tag {tag!r} must start with 'v'")
+    version_str = tag[1:]
+
+    try:
+        parsed = Version(version_str)
+    except InvalidVersion:
+        raise SystemExit(f"Release tag {tag!r} is not a valid PEP 440 version")
+
+    if str(parsed) != version_str:
+        raise SystemExit(
+            f"Release tag {tag!r} is not canonical; expected 'v{parsed}'"
+        )
+
+    base = _read_version(pyproject_path)
+    if parsed.base_version != base:
+        raise SystemExit(
+            f"Release tag base '{parsed.base_version}' does not match "
+            f"pyproject version '{base}'"
+        )
+
+    if prerelease:
+        is_rc = parsed.pre is not None and parsed.pre[0] == "rc"
+        if not is_rc or parsed.is_devrelease or parsed.is_postrelease \
+                or parsed.local is not None:
+            raise SystemExit(
+                f"Pre-release tag {tag!r} must be a release candidate "
+                f"'v{base}rcN'"
+            )
+    elif version_str != base:
+        raise SystemExit(
+            f"Release tag {tag!r} must be a final version 'v{base}'"
+        )
+
+    _write_version(pyproject_path, version_str)
+    return version_str
+
+
 def main(argv: list[str]) -> None:
     if len(argv) < 2:
         raise SystemExit(_USAGE)
@@ -89,6 +144,17 @@ def main(argv: list[str]) -> None:
             raise SystemExit(_USAGE)
         rc_version = set_rc_version(pathlib.Path(argv[3]), argv[2])
         print(f"::notice::Building release candidate {rc_version}")
+    elif command == "set-release":
+        args = argv[2:]
+        prerelease = "--prerelease" in args
+        positionals = [arg for arg in args if arg != "--prerelease"]
+        if len(positionals) != 2:
+            raise SystemExit(_USAGE)
+        tag, pyproject_path = positionals
+        version = set_release_version(
+            pathlib.Path(pyproject_path), tag, prerelease=prerelease
+        )
+        print(f"::notice::Building release {version}")
     else:
         raise SystemExit(_USAGE)
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,11 +19,11 @@ on:
     types: [published]
   workflow_dispatch:
     inputs:
-      target:
-        description: "Where to publish"
+      kind:
+        description: "Test build kind (dev→TestPyPI, rc→PyPI)"
         type: choice
-        options: [testpypi, pypi]
-        default: testpypi
+        options: [dev, rc]
+        default: dev
       dry_run:
         description: "Build only, do not publish"
         type: boolean
@@ -43,19 +43,28 @@ jobs:
     - name: Install version tooling
       run: |
         python -m pip install --upgrade pip
-        pip install tomlkit==0.15.0
+        pip install tomlkit==0.15.0 packaging==25.0
+    - name: Set version from release tag
+      # A published GitHub Release publishes the tag-derived version: full
+      # releases as vX.Y.Z, pre-releases as vX.Y.ZrcN. version_tool validates the
+      # tag (canonical PEP 440, base matching pyproject, rc-only pre-releases)
+      # and fails fast on any mismatch before anything is built or published.
+      if: github.event_name == 'release'
+      env:
+        TAG: ${{ github.event.release.tag_name }}
+        PRERELEASE_FLAG: ${{ github.event.release.prerelease && '--prerelease' || '' }}
+      run: python .github/scripts/version_tool.py set-release "$TAG" pyproject.toml $PRERELEASE_FLAG
     - name: Set dev version for TestPyPI builds
       # TestPyPI rejects re-uploading an existing version, so any build destined
       # for it gets a unique .devN suffix (PEP 440) — this covers pushes to main
-      # and manual dispatches targeting testpypi. Full releases keep the pinned
-      # version from pyproject.toml for PyPI.
-      if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi')
+      # and manual dev dispatches.
+      if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.kind == 'dev')
       run: python .github/scripts/version_tool.py set-dev ${{ github.run_number }} pyproject.toml
-    - name: Set release candidate version for pre-releases
-      # A GitHub pre-release is published to PyPI as a PEP 440 release candidate
+    - name: Set release candidate version for rc dispatches
+      # A manual rc dispatch is published to PyPI as a PEP 440 release candidate
       # (base version + rcN, where N is the run number for uniqueness). pip hides
       # release candidates from default installs unless users pass --pre.
-      if: github.event_name == 'release' && github.event.release.prerelease
+      if: github.event_name == 'workflow_dispatch' && inputs.kind == 'rc'
       run: python .github/scripts/version_tool.py set-rc ${{ github.run_number }} pyproject.toml
     - name: Build distributions
       run: |
@@ -69,9 +78,10 @@ jobs:
         VERSION=$(python .github/scripts/version_tool.py get pyproject.toml)
         echo "value=$VERSION" >> "$GITHUB_OUTPUT"
     - name: Tag the build commit
-      # Tag the exact commit that produced this build for traceability. Dev
-      # builds get a unique vX.Y.Z.devN tag; pinned builds reuse vX.Y.Z, which
-      # may already exist (e.g. for a release) — in that case tagging is skipped.
+      # Tag the exact commit that produced this build for traceability. Dev and
+      # rc dispatches get a unique vX.Y.Z.devN / vX.Y.ZrcN tag; release builds
+      # reuse the existing release tag (vX.Y.Z or vX.Y.ZrcN), so tagging is
+      # skipped.
       env:
         TAG: v${{ steps.version.outputs.value }}
       run: |
@@ -101,10 +111,10 @@ jobs:
       run: gh release upload "$TAG" dist/* --clobber
 
   publish-testpypi-job:
-    # Pushes to main always publish here; manual dispatches do so when
-    # target=testpypi and dry_run is disabled.
+    # Pushes to main always publish here; manual dev dispatches do so when
+    # dry_run is disabled.
     needs: build-job
-    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi' && inputs.dry_run == false)
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.kind == 'dev' && inputs.dry_run == false)
     runs-on: ubuntu-latest
     environment:
       name: testpypi
@@ -125,10 +135,10 @@ jobs:
 
   publish-pypi-job:
     # Any published GitHub Release goes to PyPI: pre-releases as rcN release
-    # candidates, full releases as the pinned version. Manual dispatches do so
-    # when target=pypi and dry_run is disabled.
+    # candidates, full releases as the pinned version. Manual rc dispatches also
+    # publish here (as rcN) when dry_run is disabled.
     needs: build-job
-    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.target == 'pypi' && inputs.dry_run == false)
+    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.kind == 'rc' && inputs.dry_run == false)
     runs-on: ubuntu-latest
     environment:
       name: pypi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,145 @@
+# Publishes distributions to TestPyPI / PyPI using OIDC Trusted Publishing
+# (no API tokens stored as secrets).
+#
+# One-time manual setup required before this workflow can publish:
+#   1. Register a Trusted Publisher on PyPI (https://pypi.org/manage/account/publishing/):
+#        Owner: ben42code | Repository: myitertools
+#        Workflow: release.yml | Environment: pypi
+#   2. Register a Trusted Publisher on TestPyPI (https://test.pypi.org/manage/account/publishing/):
+#        same owner/repository/workflow | Environment: testpypi
+#   3. Create the GitHub environments (Settings > Environments): pypi and testpypi.
+#      Names must match the registrations above and the `environment:` blocks below.
+#      Add protection rules (e.g. required reviewers) on `pypi` as desired.
+# See https://docs.pypi.org/trusted-publishers/ for details.
+name: publish-release-actions
+on:
+  push:
+    branches: [main]
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Where to publish"
+        type: choice
+        options: [testpypi, pypi]
+        default: testpypi
+      dry_run:
+        description: "Build only, do not publish"
+        type: boolean
+        default: true
+
+jobs:
+  build-job:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # required to push the build tag
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
+    - name: Install version tooling
+      run: |
+        python -m pip install --upgrade pip
+        pip install tomlkit==0.15.0
+    - name: Set dev version for TestPyPI builds
+      # TestPyPI rejects re-uploading an existing version, so any build destined
+      # for it gets a unique .devN suffix (PEP 440) — this covers pushes to main
+      # and manual dispatches targeting testpypi. Full releases keep the pinned
+      # version from pyproject.toml for PyPI.
+      if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi')
+      run: python .github/scripts/version_tool.py set-dev ${{ github.run_number }} pyproject.toml
+    - name: Set release candidate version for pre-releases
+      # A GitHub pre-release is published to PyPI as a PEP 440 release candidate
+      # (base version + rcN, where N is the run number for uniqueness). pip hides
+      # release candidates from default installs unless users pass --pre.
+      if: github.event_name == 'release' && github.event.release.prerelease
+      run: python .github/scripts/version_tool.py set-rc ${{ github.run_number }} pyproject.toml
+    - name: Build distributions
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
+        python -m build
+    - name: Resolve build version
+      id: version
+      run: |
+        set -euo pipefail
+        VERSION=$(python .github/scripts/version_tool.py get pyproject.toml)
+        echo "value=$VERSION" >> "$GITHUB_OUTPUT"
+    - name: Tag the build commit
+      # Tag the exact commit that produced this build for traceability. Dev
+      # builds get a unique vX.Y.Z.devN tag; pinned builds reuse vX.Y.Z, which
+      # may already exist (e.g. for a release) — in that case tagging is skipped.
+      env:
+        TAG: v${{ steps.version.outputs.value }}
+      run: |
+        if [ -n "$(git ls-remote --tags origin "refs/tags/$TAG")" ]; then
+          echo "::notice::Tag $TAG already exists, skipping"
+        else
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag "$TAG" "$GITHUB_SHA"
+          git push origin "$TAG"
+          echo "::notice::Created tag $TAG on $GITHUB_SHA"
+        fi
+    - name: Upload distributions
+      uses: actions/upload-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Attach distributions to the GitHub Release
+      # Publish the built wheel/sdist as assets on the release page. Only for
+      # full releases: their version matches the tag (vX.Y.Z), and they are the
+      # durable artifacts. Pre-releases are transient and already on PyPI
+      # (installable via pip --pre). --clobber makes re-runs idempotent.
+      if: github.event_name == 'release' && !github.event.release.prerelease
+      env:
+        GH_TOKEN: ${{ github.token }}
+        TAG: ${{ github.event.release.tag_name }}
+      run: gh release upload "$TAG" dist/* --clobber
+
+  publish-testpypi-job:
+    # Pushes to main always publish here; manual dispatches do so when
+    # target=testpypi and dry_run is disabled.
+    needs: build-job
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi' && inputs.dry_run == false)
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/project/ben42code.myitertools/
+    permissions:
+      id-token: write  # required for TestPyPI Trusted Publishing (OIDC)
+    steps:
+    - name: Download distributions
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish to TestPyPI
+      # repository-url overrides the action's default (PyPI) to target TestPyPI.
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/
+
+  publish-pypi-job:
+    # Any published GitHub Release goes to PyPI: pre-releases as rcN release
+    # candidates, full releases as the pinned version. Manual dispatches do so
+    # when target=pypi and dry_run is disabled.
+    needs: build-job
+    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.target == 'pypi' && inputs.dry_run == false)
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/ben42code.myitertools/
+    permissions:
+      id-token: write  # required for PyPI Trusted Publishing (OIDC)
+    steps:
+    - name: Download distributions
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,7 @@ flake8==7.1.0
 # VSCode - Unit test
 packaging==25.0 # required since .vscode\extensions\ms-python.python-2025.5.2025042501-win32-x64\python_files\unittestadapter\execution.py is not selfcontained
 
+# CI - release workflow version tooling (.github/scripts/version_tool.py)
+tomlkit==0.15.0
+
 # Project

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ coverage==7.5.1
 flake8==7.1.0
 
 # VSCode - Unit test
-packaging==25.0 # required since .vscode\extensions\ms-python.python-2025.5.2025042501-win32-x64\python_files\unittestadapter\execution.py is not selfcontained
+packaging==25.0 # VSCode unittest adapter (not selfcontained) + release version tooling (.github/scripts/version_tool.py)
 
 # CI - release workflow version tooling (.github/scripts/version_tool.py)
 tomlkit==0.15.0

--- a/tests/unit/version_tool_test.py
+++ b/tests/unit/version_tool_test.py
@@ -145,6 +145,86 @@ class TestVersionTool(unittest.TestCase):
                     set_version(path, "42")
                 self.assertEqual(path.read_text(), original)
 
+    def test_setReleaseVersion_withMatchingFinalTag_writesVersion(self):
+        # arrange
+        path = self._writePyproject('[project]\nversion = "0.0.6"\n')
+
+        # act
+        result = version_tool.set_release_version(path, "v0.0.6", prerelease=False)
+
+        # assert
+        self.assertEqual(result, "0.0.6")
+        self.assertIn('version = "0.0.6"', path.read_text())
+
+    def test_setReleaseVersion_withMatchingRcTag_writesVersion(self):
+        # arrange
+        path = self._writePyproject('[project]\nversion = "0.0.6"\n')
+
+        # act
+        result = version_tool.set_release_version(path, "v0.0.6rc1", prerelease=True)
+
+        # assert
+        self.assertEqual(result, "0.0.6rc1")
+        self.assertIn('version = "0.0.6rc1"', path.read_text())
+
+    def test_setReleaseVersion_withInvalidTag_raisesSystemExit(self):
+        cases = [
+            ("0.0.6", False),          # missing 'v' prefix
+            ("vnot-a-version", False),  # invalid PEP 440
+            ("v0.0.6.rc1", True),      # non-canonical rc separator
+            ("v0.0.6-rc1", True),      # non-canonical rc separator
+            ("v0.0.7", False),         # base mismatch (final)
+            ("v0.0.7rc1", True),       # base mismatch (prerelease)
+            ("v0.0.6rc1", False),      # rc tag for a final release
+            ("v0.0.6", True),          # final tag for a pre-release
+            ("v0.0.6b1", True),        # beta is not a release candidate
+            ("v0.0.6a1", True),        # alpha is not a release candidate
+            ("v0.0.6rc1.dev1", True),  # dev segment on a pre-release
+            ("v0.0.6rc1.post1", True),  # post segment on a pre-release
+            ("v0.0.6rc1+local", True),  # local segment on a pre-release
+        ]
+        for tag, prerelease in cases:
+            with self.subTest(tag=tag, prerelease=prerelease):
+                # arrange
+                path = self._writePyproject('[project]\nversion = "0.0.6"\n')
+
+                # act / assert
+                with self.assertRaises(SystemExit):
+                    version_tool.set_release_version(path, tag, prerelease=prerelease)
+                self.assertIn('version = "0.0.6"', path.read_text())
+
+    def test_main_setRelease_rewritesVersion(self):
+        cases = [
+            ([], "v0.0.6", "0.0.6"),
+            (["--prerelease"], "v0.0.6rc1", "0.0.6rc1"),
+        ]
+        for flag, tag, expected in cases:
+            with self.subTest(flag=flag):
+                # arrange
+                path = self._writePyproject('[project]\nversion = "0.0.6"\n')
+
+                # act
+                version_tool.main(["prog", "set-release", tag, str(path)] + flag)
+
+                # assert
+                self.assertIn(f'version = "{expected}"', path.read_text())
+
+    def test_main_setRelease_withWrongArgCount_raisesSystemExit(self):
+        # arrange
+        path = self._writePyproject('[project]\nversion = "0.0.6"\n')
+
+        # act / assert
+        with self.assertRaises(SystemExit):
+            version_tool.main(["prog", "set-release", str(path)])
+
+    def test_main_setRelease_withUnknownFlag_raisesSystemExit(self):
+        # arrange
+        path = self._writePyproject('[project]\nversion = "0.0.6"\n')
+
+        # act / assert
+        with self.assertRaises(SystemExit):
+            version_tool.main(["prog", "set-release", "v0.0.6", str(path), "--bogus"])
+
     def test_main_get_printsVersion(self):
         # arrange
         path = self._writePyproject('[project]\nversion = "0.0.6"\n')

--- a/tests/unit/version_tool_test.py
+++ b/tests/unit/version_tool_test.py
@@ -1,0 +1,200 @@
+import contextlib
+import importlib.util
+import io
+import os
+import pathlib
+import tempfile
+import unittest
+
+_SCRIPT_PATH = pathlib.Path(__file__).resolve().parents[2] / ".github" / "scripts" / "version_tool.py"
+_spec = importlib.util.spec_from_file_location("version_tool", _SCRIPT_PATH)
+version_tool = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(version_tool)
+
+
+class TestVersionTool(unittest.TestCase):
+    def _writePyproject(self, body: str) -> pathlib.Path:
+        handle, name = tempfile.mkstemp(suffix=".toml")
+        os.close(handle)
+        path = pathlib.Path(name)
+        path.write_text(body)
+        self.addCleanup(path.unlink)
+        return path
+
+    def test_getVersion_withProjectVersion_returnsVersion(self):
+        # arrange
+        path = self._writePyproject('[project]\nname = "x"\nversion = "0.0.6"\n')
+
+        # act
+        result = version_tool.get_version(path)
+
+        # assert
+        self.assertEqual(result, "0.0.6")
+
+    def test_getVersion_withNoProjectTable_raisesSystemExit(self):
+        # arrange
+        path = self._writePyproject('[build-system]\nrequires = ["flit_core"]\n')
+
+        # act / assert
+        with self.assertRaises(SystemExit):
+            version_tool.get_version(path)
+
+    def test_getVersion_withNoVersionKey_raisesSystemExit(self):
+        # arrange
+        path = self._writePyproject('[project]\nname = "x"\n')
+
+        # act / assert
+        with self.assertRaises(SystemExit):
+            version_tool.get_version(path)
+
+    def test_getVersion_withFormattingVariants_stillParses(self):
+        variants = [
+            '[project]\nversion="1.2.3"\n',          # no spaces
+            "[project]\nversion = '1.2.3'\n",        # single quotes
+            '[project]\nversion  =  "1.2.3"\n',      # extra spaces
+            '[project]\nversion\t=\t"1.2.3"\n',      # tabs
+            '[project]\nversion = "1.2.3"   \n',     # trailing spaces
+            '[project]\nversion = "1.2.3"  # note\n',  # trailing comment
+        ]
+        for body in variants:
+            with self.subTest(body=body):
+                path = self._writePyproject(body)
+                self.assertEqual(version_tool.get_version(path), "1.2.3")
+
+    def test_getVersion_withMalformedToml_raisesSystemExit(self):
+        # unquoted value and mismatched quotes are invalid TOML
+        for body in ('[project]\nversion =1.2.3\n', '[project]\nversion = "1.2.3\'\n'):
+            with self.subTest(body=body):
+                path = self._writePyproject(body)
+                with self.assertRaises(SystemExit):
+                    version_tool.get_version(path)
+
+    def test_setVersion_appendsSuffix(self):
+        cases = [
+            (version_tool.set_dev_version, "0.0.6.dev42"),
+            (version_tool.set_rc_version, "0.0.6rc42"),
+        ]
+        for set_version, expected in cases:
+            with self.subTest(set_version=set_version.__name__):
+                # arrange
+                path = self._writePyproject('[project]\nversion = "0.0.6"\n')
+
+                # act
+                result = set_version(path, "42")
+
+                # assert
+                self.assertEqual(result, expected)
+                self.assertIn(f'version = "{expected}"', path.read_text())
+
+    def test_setVersion_onlyTouchesProjectVersion(self):
+        cases = [
+            (version_tool.set_dev_version, "1.2.3.dev7"),
+            (version_tool.set_rc_version, "1.2.3rc7"),
+        ]
+        for set_version, expected in cases:
+            with self.subTest(set_version=set_version.__name__):
+                # arrange
+                path = self._writePyproject(
+                    '[project]\nversion = "1.2.3"\n\n[tool.other]\nversion = "9.9.9"\n'
+                )
+
+                # act
+                set_version(path, "7")
+
+                # assert
+                content = path.read_text()
+                self.assertIn(f'version = "{expected}"', content)
+                self.assertIn('version = "9.9.9"', content)
+
+    def test_setVersion_preservesFormattingAndComments(self):
+        cases = [
+            (version_tool.set_dev_version, "0.0.6.dev3"),
+            (version_tool.set_rc_version, "0.0.6rc3"),
+        ]
+        for set_version, expected in cases:
+            with self.subTest(set_version=set_version.__name__):
+                # arrange
+                body = (
+                    "# top comment\n"
+                    "[project]\n"
+                    'name = "x"  # inline\n'
+                    'version = "0.0.6"\n'
+                    'dependencies = []\n'
+                )
+                path = self._writePyproject(body)
+
+                # act
+                set_version(path, "3")
+
+                # assert
+                content = path.read_text()
+                self.assertIn("# top comment", content)
+                self.assertIn('name = "x"  # inline', content)
+                self.assertIn("dependencies = []", content)
+                self.assertIn(f'version = "{expected}"', content)
+
+    def test_setVersion_withMalformedToml_raisesAndLeavesFileUntouched(self):
+        for set_version in (version_tool.set_dev_version, version_tool.set_rc_version):
+            with self.subTest(set_version=set_version.__name__):
+                # arrange
+                original = '[project]\nversion =1.2.3\n'
+                path = self._writePyproject(original)
+
+                # act / assert
+                with self.assertRaises(SystemExit):
+                    set_version(path, "42")
+                self.assertEqual(path.read_text(), original)
+
+    def test_main_get_printsVersion(self):
+        # arrange
+        path = self._writePyproject('[project]\nversion = "0.0.6"\n')
+
+        # act
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            version_tool.main(["prog", "get", str(path)])
+
+        # assert
+        self.assertEqual(stdout.getvalue().strip(), "0.0.6")
+
+    def test_main_setCommand_rewritesVersion(self):
+        cases = [("set-dev", "0.0.6.dev5"), ("set-rc", "0.0.6rc5")]
+        for command, expected in cases:
+            with self.subTest(command=command):
+                # arrange
+                path = self._writePyproject('[project]\nversion = "0.0.6"\n')
+
+                # act
+                version_tool.main(["prog", command, "5", str(path)])
+
+                # assert
+                self.assertIn(f'version = "{expected}"', path.read_text())
+
+    def test_main_withUnknownCommand_raisesSystemExit(self):
+        # act / assert
+        with self.assertRaises(SystemExit):
+            version_tool.main(["prog", "bogus", "pyproject.toml"])
+
+    def test_main_withNoCommand_raisesSystemExit(self):
+        # act / assert
+        with self.assertRaises(SystemExit):
+            version_tool.main(["prog"])
+
+    def test_main_get_withWrongArgCount_raisesSystemExit(self):
+        # act / assert
+        with self.assertRaises(SystemExit):
+            version_tool.main(["prog", "get"])
+
+    def test_main_setCommand_withWrongArgCount_raisesSystemExit(self):
+        # arrange
+        path = self._writePyproject('[project]\nversion = "0.0.6"\n')
+
+        # act / assert
+        for command in ("set-dev", "set-rc"):
+            with self.subTest(command=command):
+                with self.assertRaises(SystemExit):
+                    version_tool.main(["prog", command, str(path)])
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
GitHub Actions release pipeline using OIDC Trusted Publishing:

• Push to  main  →  .devN  → TestPyPI
•  workflow_dispatch  (dev/rc,  dry_run  default true) → TestPyPI/PyPI
• GitHub Release → tag-derived version → PyPI

 version_tool.py  owns the pyproject version;  set-release  validates the tag and fails fast on mismatch. Tested on Python 3.10–3.14, 100% coverage, flake8 clean.

⚠️ Needs one-time Trusted Publisher setup (documented in workflow header).